### PR TITLE
__init__.py: from util import *

### DIFF
--- a/dpath/__init__.py
+++ b/dpath/__init__.py
@@ -9,3 +9,5 @@ else:
 
 PY2 = ( python_major_version == 2 )
 PY3 = ( python_major_version == 3 )  
+
+from .util import *


### PR DESCRIPTION
It feels a little strange and unpythonic that as a client I have to import from a submodule - e.g.: `import dpath.util; dpath.util.get(d, path)`. 

It seems nicer to be able to import and use the top-level package - e.g.: `import dpath; dpath.get(d, path)`