### PR TITLE
Fixes #30: Allow usage of lists as paths

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -408,6 +408,19 @@ setting a library-wide dpath option:
 Again, by default, this behavior is OFF, and empty string keys will
 result in ``dpath.exceptions.InvalidKeyName`` being thrown.
 
+Separator got you down? Use lists as paths
+==========================================
+
+The default behavior in dpath is to assume that the path given is a string, which must be tokenized by splitting at the separator to yield a distinct set of path components against which dictionary keys can be individually glob tested. However, this presents a problem when you want to use paths that have a separator in their name; the tokenizer cannot properly understand what you mean by '/a/b/c' if it is possible for '/' to exist as a valid character in a key name.
+
+To get around this, you can sidestep the whole "filesystem path" style, and abandon the separator entirely, by using lists as paths. All of the methods in dpath.util.* support the use of a list instead of a string as a path. So for example:
+
+.. code-block: python
+
+   >>> x = { 'a': {'b/c': 0}}
+   >>> dpath.util.get(['a', 'b/c'])
+   0
+
 dpath.path : The Undocumented Backend
 =====================================
 

--- a/dpath/path.py
+++ b/dpath/path.py
@@ -42,7 +42,7 @@ def paths_only(path):
         l.append(p[0])
     return l
 
-def validate(path, separator="/", regex=None):
+def validate(path, regex=None):
     """
     Validate that all the keys in the given list of path components are valid, given that they do not contain the separator, and match any optional regex given.
     """
@@ -50,19 +50,14 @@ def validate(path, separator="/", regex=None):
     for elem in path:
         key = elem[0]
         strkey = str(key)
-        if (separator and (separator in strkey)):
-            raise dpath.exceptions.InvalidKeyName("{0} at {1} contains the separator {2}"
-                                                  "".format(strkey,
-                                                            separator.join(validated),
-                                                            separator))
-        elif (regex and (not regex.findall(strkey))):
+        if (regex and (not regex.findall(strkey))):
             raise dpath.exceptions.InvalidKeyName("{} at {} does not match the expression {}"
                                                   "".format(strkey,
-                                                            separator.join(validated),
+                                                            validated,
                                                             regex.pattern))
         validated.append(strkey)
 
-def paths(obj, dirs=True, leaves=True, path=[], skip=False, separator="/"):
+def paths(obj, dirs=True, leaves=True, path=[], skip=False):
     """Yield all paths of the object.
 
     Arguments:
@@ -94,17 +89,17 @@ def paths(obj, dirs=True, leaves=True, path=[], skip=False, separator="/"):
                 elif (skip and k[0] == '+'):
                     continue
             newpath = path + [[k, v.__class__]]
-            validate(newpath, separator=separator)
+            validate(newpath)
             if dirs:
                 yield newpath
-            for child in paths(v, dirs, leaves, newpath, skip, separator=separator):
+            for child in paths(v, dirs, leaves, newpath, skip):
                 yield child
     elif isinstance(obj, (list, tuple)):
         for (i, v) in enumerate(obj):
             newpath = path + [[i, v.__class__]]
             if dirs:
                 yield newpath
-            for child in paths(obj[i], dirs, leaves, newpath, skip, separator=separator):
+            for child in paths(obj[i], dirs, leaves, newpath, skip):
                 yield child
     elif leaves:
         yield path + [[obj, obj.__class__]]
@@ -150,7 +145,7 @@ def match(path, glob):
 def is_glob(string):
     return any([c in string for c in '*?[]!'])
 
-def set(obj, path, value, create_missing=True, separator="/", afilter=None):
+def set(obj, path, value, create_missing=True, afilter=None):
     """Set the value of the given path in the object. Path
     must be a list of specific path elements, not a glob.
     You can use dpath.util.set for globs, but the paths must
@@ -208,7 +203,7 @@ def set(obj, path, value, create_missing=True, separator="/", afilter=None):
             if not str(elem_value).isdigit():
                 raise TypeError("Can only create integer indexes in lists, "
                                 "not {}, in {}".format(type(obj),
-                                                       separator.join(traversed)
+                                                       traversed
                                                        )
                                 )
             tester = _presence_test_list
@@ -217,7 +212,7 @@ def set(obj, path, value, create_missing=True, separator="/", afilter=None):
             assigner = _assigner_list
         else:
             raise TypeError("Unable to path into elements of type {} "
-                            "at {}".format(obj, separator.join(traversed)))
+                            "at {}".format(obj, traversed))
 
         if (not tester(obj, elem)) and (create_missing):
             creator(obj, elem)
@@ -225,7 +220,7 @@ def set(obj, path, value, create_missing=True, separator="/", afilter=None):
             raise dpath.exceptions.PathNotFound(
                 "{} does not exist in {}".format(
                     elem,
-                    separator.join(traversed)
+                    traversed
                     )
                 )
         traversed.append(elem_value)

--- a/tests/test_path_get.py
+++ b/tests/test_path_get.py
@@ -16,4 +16,3 @@ def test_path_get_list_of_dicts():
     assert(isinstance(res['a']['b'], list))
     assert(len(res['a']['b']) == 1)
     assert(res['a']['b'][0][0] == 0)
-

--- a/tests/test_path_paths.py
+++ b/tests/test_path_paths.py
@@ -5,14 +5,6 @@ import dpath.exceptions
 import dpath.options
 
 @raises(dpath.exceptions.InvalidKeyName)
-def test_path_paths_invalid_keyname():
-    tdict = {
-        "I/contain/the/separator": 0
-        }
-    for x in dpath.path.paths(tdict):
-        pass
-
-@raises(dpath.exceptions.InvalidKeyName)
 def test_path_paths_empty_key_disallowed():
     tdict = {
         "Empty": {

--- a/tests/test_util_get_values.py
+++ b/tests/test_util_get_values.py
@@ -16,6 +16,7 @@ def test_get_explicit_single():
             }
         }
     assert(dpath.util.get(ehash, '/a/b/c/f') == 2)
+    assert(dpath.util.get(ehash, ['a', 'b', 'c', 'f']) == 2)
 
 def test_get_glob_single():
     ehash = {
@@ -30,6 +31,7 @@ def test_get_glob_single():
             }
         }
     assert(dpath.util.get(ehash, '/a/b/*/f') == 2)
+    assert(dpath.util.get(ehash, ['a', 'b', '*', 'f']) == 2)
 
 def test_get_glob_multiple():
     ehash = {
@@ -45,10 +47,12 @@ def test_get_glob_multiple():
         }
     }
     assert_raises(ValueError, dpath.util.get, ehash, '/a/b/*/d')
+    assert_raises(ValueError, dpath.util.get, ehash, ['a', 'b', '*', 'd'])
 
 def test_get_absent():
     ehash = {}
     assert_raises(KeyError, dpath.util.get, ehash, '/a/b/c/d/f')
+    assert_raises(KeyError, dpath.util.get, ehash, ['a', 'b', 'c', 'd', 'f'])
 
 def test_values():
     ehash = {
@@ -68,6 +72,12 @@ def test_values():
     assert(1 in ret)
     assert(2 in ret)
 
+    ret = dpath.util.values(ehash, ['a', 'b', 'c', '*'])
+    assert(isinstance(ret, list))
+    assert(0 in ret)
+    assert(1 in ret)
+    assert(2 in ret)
+
 @mock.patch('dpath.util.search')
 def test_values_passes_through(searchfunc):
     searchfunc.return_value = []
@@ -75,3 +85,5 @@ def test_values_passes_through(searchfunc):
         pass
     dpath.util.values({}, '/a/b', ':', y, False)
     searchfunc.assert_called_with({}, '/a/b', dirs=False, yielded=True, separator=':', afilter=y)
+    dpath.util.values({}, ['a', 'b'], ':', y, False)
+    searchfunc.assert_called_with({}, ['a', 'b'], dirs=False, yielded=True, separator=':', afilter=y)

--- a/tests/test_util_new.py
+++ b/tests/test_util_new.py
@@ -8,6 +8,8 @@ def test_set_new_separator():
         }
     dpath.util.new(dict, ';a;b', 1, separator=";")
     assert(dict['a']['b'] == 1)
+    dpath.util.new(dict, ['a', 'b'], 1, separator=";")
+    assert(dict['a']['b'] == 1)
 
 def test_set_new_dict():
     dict = {
@@ -15,6 +17,8 @@ def test_set_new_dict():
             }
         }
     dpath.util.new(dict, '/a/b', 1)
+    assert(dict['a']['b'] == 1)
+    dpath.util.new(dict, ['a', 'b'], 1)
     assert(dict['a']['b'] == 1)
 
 def test_set_new_list():
@@ -25,3 +29,17 @@ def test_set_new_list():
     dpath.util.new(dict, '/a/1', 1)
     assert(dict['a'][1] == 1)
     assert(dict['a'][0] == None)
+    dpath.util.new(dict, ['a', '1'], 1)
+    assert(dict['a'][1] == 1)
+    assert(dict['a'][0] == None)
+
+def test_set_new_list_path_with_separator():
+    # This test kills many birds with one stone, forgive me
+    dict = {
+        "a": {}
+        }
+    dpath.util.new(dict, ['a', 'b/c/d', 0], 1)
+    assert(len(dict['a']) == 1)
+    assert(len(dict['a']['b/c/d']) == 1)
+    assert(dict['a']['b/c/d'][0] == 1)
+    

--- a/tests/test_util_paths.py
+++ b/tests/test_util_paths.py
@@ -1,0 +1,9 @@
+import nose
+from nose.tools import raises
+import dpath.util
+
+def test_util_safe_path_list():
+    res = dpath.util.__safe_path__(["Ignore", "the/separator"], None)
+    assert(len(res) == 2)
+    assert(res[0] == "Ignore")
+    assert(res[1] == "the/separator")

--- a/tests/test_util_search.py
+++ b/tests/test_util_search.py
@@ -23,6 +23,8 @@ def test_search_paths_with_separator():
         ]
     for (path, value) in dpath.util.search(dict, '/**', yielded=True, separator=";"):
         assert(path in paths)
+    for (path, value) in dpath.util.search(dict, ['**'], yielded=True, separator=";"):
+        assert(path in paths)
 
 def test_search_paths():
     dict = {
@@ -45,6 +47,8 @@ def test_search_paths():
         'a/b/c/f'
         ]
     for (path, value) in dpath.util.search(dict, '/**', yielded=True):
+        assert(path in paths)
+    for (path, value) in dpath.util.search(dict, ['**'], yielded=True):
         assert(path in paths)
 
 def test_search_afilter():
@@ -73,8 +77,14 @@ def test_search_afilter():
         ]
     for (path, value) in dpath.util.search(dict, '/**', yielded=True, afilter=afilter):
         assert(path in paths)
+    print dpath.util.search(dict, '/**', afilter=afilter)
     assert("view_failure" not in dpath.util.search(dict, '/**', afilter=afilter)['a'])
     assert("d" not in dpath.util.search(dict, '/**', afilter=afilter)['a']['b']['c'])
+
+    for (path, value) in dpath.util.search(dict, ['**'], yielded=True, afilter=afilter):
+        assert(path in paths)
+    assert("view_failure" not in dpath.util.search(dict, ['**'], afilter=afilter)['a'])
+    assert("d" not in dpath.util.search(dict, ['**'], afilter=afilter)['a']['b']['c'])
 
 def test_search_globbing():
     dict = {
@@ -94,6 +104,8 @@ def test_search_globbing():
         ]
     for (path, value) in dpath.util.search(dict, '/a/**/[df]', yielded=True):
         assert(path in paths)
+    for (path, value) in dpath.util.search(dict, ['a', '**', '[df]'], yielded=True):
+        assert(path in paths)
 
 def test_search_return_dict_head():
     tdict = {
@@ -105,6 +117,11 @@ def test_search_return_dict_head():
             }
         }
     res = dpath.util.search(tdict, '/a/b')
+    assert(isinstance(res['a']['b'], dict))
+    assert(len(res['a']['b']) == 3)
+    assert(res['a']['b'] == {0: 0, 1: 1, 2: 2})
+
+    res = dpath.util.search(tdict, ['a', 'b'])
     assert(isinstance(res['a']['b'], dict))
     assert(len(res['a']['b']) == 3)
     assert(res['a']['b'] == {0: 0, 1: 1, 2: 2})
@@ -122,6 +139,10 @@ def test_search_return_dict_globbed():
     assert(isinstance(res['a']['b'], dict))
     assert(len(res['a']['b']) == 2)
     assert(res['a']['b'] == {0: 0, 2: 2})
+    res = dpath.util.search(tdict, ['a', 'b', '[02]'])
+    assert(isinstance(res['a']['b'], dict))
+    assert(len(res['a']['b']) == 2)
+    assert(res['a']['b'] == {0: 0, 2: 2})
 
 def test_search_return_list_head():
     tdict = {
@@ -133,6 +154,10 @@ def test_search_return_list_head():
             }
         }
     res = dpath.util.search(tdict, '/a/b')
+    assert(isinstance(res['a']['b'], list))
+    assert(len(res['a']['b']) == 3)
+    assert(res['a']['b'] == [0, 1, 2])
+    res = dpath.util.search(tdict, ['a', 'b'])
     assert(isinstance(res['a']['b'], list))
     assert(len(res['a']['b']) == 3)
     assert(res['a']['b'] == [0, 1, 2])
@@ -150,4 +175,21 @@ def test_search_return_list_globbed():
     assert(isinstance(res['a']['b'], list))
     assert(len(res['a']['b']) == 2)
     assert(res['a']['b'] == [0, 2])
+    res = dpath.util.search(tdict, ['a', 'b', '[02]'])
+    assert(isinstance(res['a']['b'], list))
+    assert(len(res['a']['b']) == 2)
+    assert(res['a']['b'] == [0, 2])
 
+
+def test_search_list_key_with_separator():
+    tdict = {
+        "a": {
+            "b": {
+                "d": 'failure'
+            },
+            "/b/d": 'success'
+            }
+        }
+    res = dpath.util.search(tdict, ['a', '/b/d'])
+    assert(not 'b' in res['a'])
+    assert(res['a']['/b/d'] == 'success')

--- a/tests/test_util_search.py
+++ b/tests/test_util_search.py
@@ -77,7 +77,6 @@ def test_search_afilter():
         ]
     for (path, value) in dpath.util.search(dict, '/**', yielded=True, afilter=afilter):
         assert(path in paths)
-    print dpath.util.search(dict, '/**', afilter=afilter)
     assert("view_failure" not in dpath.util.search(dict, '/**', afilter=afilter)['a'])
     assert("d" not in dpath.util.search(dict, '/**', afilter=afilter)['a']['b']['c'])
 

--- a/tests/test_util_set.py
+++ b/tests/test_util_set.py
@@ -9,6 +9,9 @@ def test_set_existing_separator():
         }
     dpath.util.set(dict, ';a;b', 1, separator=";")
     assert(dict['a']['b'] == 1)
+    dict['a']['b'] = 0
+    dpath.util.set(dict, ['a', 'b'], 1, separator=";")
+    assert(dict['a']['b'] == 1)
 
 def test_set_existing_dict():
     dict = {
@@ -18,6 +21,9 @@ def test_set_existing_dict():
         }
     dpath.util.set(dict, '/a/b', 1)
     assert(dict['a']['b'] == 1)
+    dict['a']['b'] = 0
+    dpath.util.set(dict, ['a', 'b'], 1)
+    assert(dict['a']['b'] == 1)
 
 def test_set_existing_list():
     dict = {
@@ -26,6 +32,9 @@ def test_set_existing_list():
             ]
         }
     dpath.util.set(dict, '/a/0', 1)
+    assert(dict['a'][0] == 1)
+    dict['a'][0] = 0
+    dpath.util.set(dict, ['a', '0'], 1)
     assert(dict['a'][0] == 1)
 
 def test_set_filter():
@@ -42,7 +51,29 @@ def test_set_filter():
             }
         }
     dpath.util.set(dict, '/a/*', 31337, afilter=afilter)
-    print(dict)
     assert (dict['a']['b'] == 0)
     assert (dict['a']['c'] == 1)
     assert (dict['a']['d'] == 31337)
+
+    dict = {
+        "a": {
+            "b": 0,
+            "c": 1,
+            "d": 31
+            }
+        }
+    dpath.util.set(dict, ['a', '*'], 31337, afilter=afilter)
+    assert (dict['a']['b'] == 0)
+    assert (dict['a']['c'] == 1)
+    assert (dict['a']['d'] == 31337)
+
+def test_set_existing_path_with_separator():
+    dict = {
+        "a": {
+            'b/c/d': 0
+            }
+        }
+    dpath.util.set(dict, ['a', 'b/c/d'], 1)
+    assert(len(dict['a']) == 1)
+    assert(dict['a']['b/c/d'] == 1)
+


### PR DESCRIPTION
This will fix #30 . However, it does raise a new concern. 

The implementation as-is will not tell a user who is using string paths that their dictionary contains keys with the separator in them. Because of how the code is laid out, I felt it was too hard to make the validator be aware of whether or not the user had originally passed in a string path or a list path, and therefore I just yanked the key validation entirely. But I don't know that this was the right choice. I'm thinking maybe we should create some path object types, and pass those down to dpath.path.*, so that the low level library can know this information. Something like:

    class Path:
        def __init__(self, separator='/'):
            self.__separator__ = separator
        def components(self):
            """return all path components of this path"""
    
    class StringPath(Path):
        pass
    
    class ListPath(Path):
        pass

... or something like that. This way the low level lib would know whether or not we should alert the user that their dict has separators in the keys. Of course, this all depends on whether or not we believe we should protect the user. Thoughts?

@calebcase , RFC?