### PR TITLE
Add Contributors section to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -441,3 +441,19 @@ of it. You have been warned!
 
 .. |Build Status| image:: https://travis-ci.org/akesterson/dpath-python.svg?branch=travisci
    :target: https://travis-ci.org/akesterson/dpath-python
+
+Contributors
+============
+
+We would like to thank the community for their interest and involvement. You have all made this project significantly better than the sum of its parts, and your continued feedback makes it better every day. Thank you so much!
+
+The following authors have contributed to this project, in varying capacities:
+
+Caleb Case <calebcase@gmail.com>
+Andrew Kesterson <andrew@aklabs.net>
+Marc Abramowitz <marc@marc-abramowitz.com>
+xhh2a <xhh2a@berkeley.edu>
+Stanislav Ochotnicky <sochotnicky@redhat.com>
+Misja Hoebe <misja@conversify.com>
+Gagandeep Singh <gagandeep.2020@gmail.com>
+Alan Gibson <alan.gibson@gmail.com>


### PR DESCRIPTION
It's high time we recognized our contributors in a proper way, so I'd like to add a section to the README, so it will appear on pypi.

If you object to your name being published as a contributor to this project, or if you would like me to redact or change your email address, please speak now or forever hold your peace.

@misja
@msabramo
@sochotnicky
@alangibson 
@gagandeep 
@xhh2a 
@calebcase