### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -435,7 +435,7 @@ of path components instead of string globs, and just generally does
 things in a way that you (as a frontend user) might not expect. Stay out
 of it. You have been warned!
 
-.. |PyPI| image:: https://pypip.in/version/dpath/badge.svg?style=flat
+.. |PyPI| image:: https://img.shields.io/pypi/v/dpath.svg?style=flat
     :target: https://pypi.python.org/pypi/dpath/
     :alt: PyPI: Latest Version
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20dpath))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `dpath`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.