### PR TITLE
Fixed a bug with ALLOW_EMPTY_STRING_KEYS

### DIFF
--- a/dpath/path.py
+++ b/dpath/path.py
@@ -84,9 +84,10 @@ def paths(obj, dirs=True, leaves=True, path=[], skip=False):
 
         for (k, v) in iteritems:
             if issubclass(k.__class__, (string_class)):
-                if (not k) and (not dpath.options.ALLOW_EMPTY_STRING_KEYS):
-                    raise dpath.exceptions.InvalidKeyName("Empty string keys not allowed without "
-                                                          "dpath.options.ALLOW_EMPTY_STRING_KEYS=True")
+                if not k:
+                    if not dpath.options.ALLOW_EMPTY_STRING_KEYS:
+                        raise dpath.exceptions.InvalidKeyName("Empty string keys not allowed without "
+                                                              "dpath.options.ALLOW_EMPTY_STRING_KEYS=True")
                 elif (skip and k[0] == '+'):
                     continue
             newpath = path + [[k, v.__class__]]


### PR DESCRIPTION
Prevents the following error:
```
  File "/.../local/lib/python2.7/site-packages/dpath/path.py", line 90, in paths
    elif (skip and k[0] == '+'):
IndexError: string index out of range
```

This occurs because if the path is empty but you HAVE set allow_empty_strings, the elif clause will attempt to check k[0]. We want the empty if and option if to be separate, to no longer trigger the elif check.