### PR TITLE
Fixes #72 and #73

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .tox
 MANIFEST
+*.pyc

--- a/dpath/__init__.py
+++ b/dpath/__init__.py
@@ -8,6 +8,12 @@ else:
   python_major_version = sys.version_info[0]
 
 PY2 = ( python_major_version == 2 )
-PY3 = ( python_major_version == 3 )  
+PY3 = ( python_major_version == 3 )
+
+STRING_BASE_CLASS = None
+if PY2:
+    STRING_BASE_CLASS = basestring
+elif PY3:
+    STRING_BASE_CLASS = str
 
 from .util import *

--- a/dpath/path.py
+++ b/dpath/path.py
@@ -88,7 +88,7 @@ def paths(obj, dirs=True, leaves=True, path=[], skip=False):
                 if (not k) and (not dpath.options.ALLOW_EMPTY_STRING_KEYS):
                     raise dpath.exceptions.InvalidKeyName("Empty string keys not allowed without "
                                                           "dpath.options.ALLOW_EMPTY_STRING_KEYS=True")
-                elif (skip and k[0] == '+'):
+                elif (skip and k and k[0] == '+'):
                     continue
             newpath = path + [[k, v.__class__]]
             validate(newpath)

--- a/tests/test_path_paths.py
+++ b/tests/test_path_paths.py
@@ -16,7 +16,7 @@ def test_path_paths_empty_key_disallowed():
     for x in dpath.path.paths(tdict):
         pass
 
-def test_path_paths_empty_key_allowed():
+def test_path_paths_empty_key_allowed_skip_false():
     tdict = {
         "Empty": {
             "": {
@@ -26,7 +26,25 @@ def test_path_paths_empty_key_allowed():
     }
     parts=[]
     dpath.options.ALLOW_EMPTY_STRING_KEYS=True
-    for x in dpath.path.paths(tdict, dirs=False, leaves=True):
+    for x in dpath.path.paths(tdict, dirs=False, leaves=True, skip=False):
+        path = x
+    for x in path[:-1]:
+        parts.append(x[0])
+    dpath.options.ALLOW_EMPTY_STRING_KEYS=False
+    assert("/".join(parts) == "Empty//Key")
+
+def test_path_paths_empty_key_allowed_skip_false():
+    tdict = {
+        "Empty": {
+            "": {
+                "Key": ""
+            }
+        }
+    }
+    # Confirm this works when skip=True (e.g. when coming through dpath.util.get(..)
+    parts=[]
+    dpath.options.ALLOW_EMPTY_STRING_KEYS=True
+    for x in dpath.path.paths(tdict, dirs=False, leaves=True, skip=True):
         path = x
     for x in path[:-1]:
         parts.append(x[0])

--- a/tests/test_path_paths.py
+++ b/tests/test_path_paths.py
@@ -42,3 +42,9 @@ def test_path_paths_int_keys():
             ['of', dict],
             [2, int]
             ])
+
+def test_path_paths_unicode_keys():
+    tdict = {
+        u"Key Contains Unicode \u00af\u00f5": "value does not",
+    }
+    paths = list(dpath.path.paths(tdict))


### PR DESCRIPTION
#72 The presence of unicode characters in dictionary keys were causing a problem in some cases because they were being `str(..)` even if they were already strings.
#73 The presence of empty string keys and `ALLOW_EMPTY_STRING_KEYS` wasn't playing well when `dpath.path.paths(...skip=True)`