### PR TITLE
Fixes #75 Add Loose Mutable Mapping Merges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -263,8 +263,8 @@ does.
         Merge source into destination. Like dict.update() but performs
         deep merging.
 
-        flags is an OR'ed combination of MERGE_ADDITIVE, MERGE_REPLACE, or
-        MERGE_TYPESAFE.
+        flags is an OR'ed combination of MERGE_ADDITIVE, MERGE_REPLACE
+        MERGE_TYPESAFE, or MERGE_LOOSEDICT.
             * MERGE_ADDITIVE : List objects are combined onto one long
               list (NOT a set). This is the default flag.
             * MERGE_REPLACE : Instead of combining list objects, when
@@ -273,6 +273,10 @@ does.
             * MERGE_TYPESAFE : When 2 keys at equal levels are of different
               types, raise a TypeError exception. By default, the source
               replaces the destination in this situation.
+            * MERGE_LOOSEDICT : When 2 keys at equal levels are instances
+              of MutableMapping, continue with recursive merge even if they
+              are not the exact same type. By default the destination type
+              is not changed to the source type.
 
     >>> y = {'a': {'b': { 'e': {'f': {'h': [None, 0, 1, None, 13, 14]}}}, 'c': 'RoffleWaffles'}}
     >>> print json.dumps(y, indent=4, sort_keys=True)

--- a/dpath/util.py
+++ b/dpath/util.py
@@ -6,6 +6,7 @@ from collections import MutableSequence, MutableMapping
 MERGE_REPLACE=(1 << 1)
 MERGE_ADDITIVE=(1 << 2)
 MERGE_TYPESAFE=(1 << 3)
+MERGE_LOOSEDICT=(1 << 4)
 
 def __safe_path__(path, separator):
     """
@@ -164,8 +165,8 @@ def merge(dst, src, separator="/", afilter=None, flags=MERGE_ADDITIVE, _path="")
     """Merge source into destination. Like dict.update() but performs
     deep merging.
 
-    flags is an OR'ed combination of MERGE_ADDITIVE, MERGE_REPLACE, or
-    MERGE_TYPESAFE.
+    flags is an OR'ed combination of MERGE_ADDITIVE, MERGE_REPLACE,
+    MERGE_TYPESAFE, or MERGE_LOOSEDICT.
         * MERGE_ADDITIVE : List objects are combined onto one long
           list (NOT a set). This is the default flag.
         * MERGE_REPLACE : Instead of combining list objects, when
@@ -174,6 +175,10 @@ def merge(dst, src, separator="/", afilter=None, flags=MERGE_ADDITIVE, _path="")
         * MERGE_TYPESAFE : When 2 keys at equal levels are of different
           types, raise a TypeError exception. By default, the source
           replaces the destination in this situation.
+        * MERGE_LOOSEDICT : When 2 keys at equal levels are instances
+          of MutableMapping, continue with recursive merge even if they
+          are not the exact same type. By default the destination type
+          is not changed to the source type.
     """
 
     if afilter:
@@ -184,6 +189,8 @@ def merge(dst, src, separator="/", afilter=None, flags=MERGE_ADDITIVE, _path="")
 
     def _check_typesafe(obj1, obj2, key, path):
         if not key in obj1:
+            return
+        elif ( (flags & MERGE_LOOSEDICT == MERGE_LOOSEDICT) and (isinstance(obj1[key], MutableMapping)) and (isinstance(obj2[key], MutableMapping))):
             return
         elif ( (flags & MERGE_TYPESAFE == MERGE_TYPESAFE) and (type(obj1[key]) != type(obj2[key]))):
             raise TypeError("Cannot merge objects of type {0} and {1} at {2}"

--- a/tests/test_util_merge.py
+++ b/tests/test_util_merge.py
@@ -106,3 +106,25 @@ def test_merge_typesafe():
             ]
         }
     dpath.util.merge(dst, src, flags=dpath.util.MERGE_TYPESAFE)
+
+def test_merge_loosedict():
+    class tcid(dict):
+        pass
+    src = {
+        "mm" : {
+            "a" : "v1"
+            }
+        }
+    dst = {
+        "mm" : tcid([
+            ("a","v2"),
+            ("casserole","this should keep")
+            ])
+        }
+    dpath.util.merge(dst, src, flags=dpath.util.MERGE_LOOSEDICT)
+    assert(dst["mm"]["a"] == src["mm"]["a"])
+    assert("casserole" in dst["mm"])
+
+    dpath.util.merge(dst, src)
+    assert(dst["mm"]["a"] == src["mm"]["a"])
+    assert("casserole" not in dst["mm"])


### PR DESCRIPTION
Changes to _check_typesafe and additional flag to permit merging of
MutableMapping objects at the same depth.

Issue #75 may encompass a larger set of functional equivalent object pairs, but this at least covers objects which are instances of MutableMapping.

Items that should be discussed:
1) Should the flags MERGE_TYPESAFE and MERGE_LOOSEDICT be mutually exclusive?  It seems like MERGE_TYPESAFE should imply strict type checking, in which case, MERGE_TYPESAFE should disable MERGE_LOOSEDICT and if both are selected, perhaps an error should be raised.

2) As far as the current implementation, I have no problem with putting the MERGE_LOOSEDICT check after the ...== MERGE_TYPESAFE code block, but prior to the ...!= MERGE_TYPESAFE block.  This prevents dst[v] from being popped and replaced by src[v], but allows MERGE_TYPESAFE to exhibit strict type checking, including in MutableMapping cases.

3) Does it make sense to eliminate the MERGE_LOOSEDICT flag and just include the ability to merge MutableMapping objects of differing types by default?  If so, we could set the condition to exit _check_typesafe as ...!= MERGE_TYPESAFE and ensure both obj1 and obj2 satisfy isinstance(..., MutableMapping)