### PR TITLE
import MutableSequence and MutableMapping in a future proof way

### DIFF
--- a/dpath/path.py
+++ b/dpath/path.py
@@ -6,7 +6,14 @@ import fnmatch
 import shlex
 import sys
 import traceback
-from collections import MutableSequence, MutableMapping
+try:
+    #python3, especially 3.8
+    from collections.abc import MutableSequence
+    from collections.abc import MutableMapping
+except ImportError:
+    #python2
+    from collections import MutableSequence
+    from collections import MutableMapping
 
 def path_types(obj, path):
     """

--- a/dpath/util.py
+++ b/dpath/util.py
@@ -1,7 +1,14 @@
 import dpath.path
 import dpath.exceptions
 import traceback
-from collections import MutableSequence, MutableMapping
+try:
+    #python3, especially 3.8
+    from collections.abc import MutableSequence
+    from collections.abc import MutableMapping
+except ImportError:
+    #python2
+    from collections import MutableSequence
+    from collections import MutableMapping
 
 MERGE_REPLACE=(1 << 1)
 MERGE_ADDITIVE=(1 << 2)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,7 +1,14 @@
 import nose
 import dpath.util
 from nose.tools import assert_raises
-from collections import MutableMapping, MutableSequence
+try:
+    #python3, especially 3.8
+    from collections.abc import MutableSequence
+    from collections.abc import MutableMapping
+except ImportError:
+    #python2
+    from collections import MutableSequence
+    from collections import MutableMapping
 
 class TestMapping(MutableMapping):
     def __init__(self, data={}):

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py32, py33, py34, pypy
+envlist = py26, py27, py32, py33, py34, py36, py37, pypy
 
 [testenv]
 deps =


### PR DESCRIPTION
`from collections import` is deprecated in python3.8 and causes a warning in 3.7

Warning is raised [here](https://github.com/python/cpython/blob/5f45979b63300338b68709bfe817ddae563b93fd/Lib/collections/__init__.py#L43-L52)