### PR TITLE
Fixed bug when deleting more than one item in the same list

### DIFF
--- a/dpath/util.py
+++ b/dpath/util.py
@@ -60,6 +60,7 @@ def delete(obj, glob, separator="/", afilter=None):
         # These are yielded back, don't mess up the dict.
         paths.append(path)
 
+    paths.reverse()
     for path in paths:
         cur = obj
         prev = None


### PR DESCRIPTION
Currently, if you are deleting a glob that contains more than one item in the same list and the second index becomes invalid (for example, index 0 and 3 in a list of four items) then delete will throw an IndexError. 

This fix resolves that issue and still maintains the full functionality.