### PR TITLE
LOOSEDICT changes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -279,7 +279,7 @@ does.
         deep merging.
 
         flags is an OR'ed combination of MERGE_ADDITIVE, MERGE_REPLACE
-        MERGE_TYPESAFE, or MERGE_LOOSEDICT.
+        MERGE_TYPESAFE.
             * MERGE_ADDITIVE : List objects are combined onto one long
               list (NOT a set). This is the default flag.
             * MERGE_REPLACE : Instead of combining list objects, when
@@ -288,10 +288,6 @@ does.
             * MERGE_TYPESAFE : When 2 keys at equal levels are of different
               types, raise a TypeError exception. By default, the source
               replaces the destination in this situation.
-            * MERGE_LOOSEDICT : When 2 keys at equal levels are instances
-              of MutableMapping, continue with recursive merge even if they
-              are not the exact same type. By default the destination type
-              is not changed to the source type.
 
     >>> y = {'a': {'b': { 'e': {'f': {'h': [None, 0, 1, None, 13, 14]}}}, 'c': 'RoffleWaffles'}}
     >>> print json.dumps(y, indent=4, sort_keys=True)

--- a/dpath/util.py
+++ b/dpath/util.py
@@ -233,11 +233,13 @@ def merge(dst, src, separator="/", afilter=None, flags=MERGE_ADDITIVE, _path="")
     def _check_typesafe(obj1, obj2, key, path):
         if not key in obj1:
             return
-        elif ( (flags & MERGE_LOOSEDICT == MERGE_LOOSEDICT) and (isinstance(obj1[key], MutableMapping)) and (isinstance(obj2[key], MutableMapping))):
-            return
         elif ( (flags & MERGE_TYPESAFE == MERGE_TYPESAFE) and (type(obj1[key]) != type(obj2[key]))):
             raise TypeError("Cannot merge objects of type {0} and {1} at {2}"
                             "".format(type(obj1[key]), type(obj2[key]), path))
+        elif ( (isinstance(obj1[key], MutableMapping)) and (isinstance(obj2[key], MutableMapping)) or
+               (isinstance(obj1[key], MutableSequence)) and (isinstance(obj2[key], MutableSequence))
+        ):
+            return
         elif ( (flags & MERGE_TYPESAFE != MERGE_TYPESAFE) and (type(obj1[key]) != type(obj2[key]))):
             obj1.pop(key)
 

--- a/tests/test_util_merge.py
+++ b/tests/test_util_merge.py
@@ -19,6 +19,7 @@ def test_merge_typesafe_and_separator():
         dpath.util.merge(dst, src, flags=(dpath.util.MERGE_ADDITIVE | dpath.util.MERGE_TYPESAFE), separator=";")
     except TypeError as e:
         assert(str(e).endswith("dict;integer"))
+        
         return
     raise Exception("MERGE_TYPESAFE failed to raise an exception when merging between str and int!")
 
@@ -108,34 +109,35 @@ def test_merge_typesafe():
         }
     dpath.util.merge(dst, src, flags=dpath.util.MERGE_TYPESAFE)
 
-@raises(ValueError)
-def test_merge_loosedict():
+@raises(TypeError)
+def test_merge_mutables():
     class tcid(dict):
         pass
+    class tcis(list):
+        pass
+    
     src = {
         "mm" : {
             "a" : "v1"
-            }
+            },
+        "ms": [
+            0
+        ]
         }
     dst = {
         "mm" : tcid([
             ("a","v2"),
             ("casserole","this should keep")
-            ])
+            ]),
+        "ms" : tcis(['a', 'b', 'c'])
         }
-    dpath.util.merge(dst, src, flags=dpath.util.MERGE_LOOSEDICT)
-    assert(dst["mm"]["a"] == src["mm"]["a"])
-    assert("casserole" in dst["mm"])
-
     dpath.util.merge(dst, src)
+    print(dst)
     assert(dst["mm"]["a"] == src["mm"]["a"])
-    assert("casserole" not in dst["mm"])
-
-    dpath.util.merge(
-        dst,
-        src,
-        flags=(dpath.util.MERGE_LOOSEDICT | dpath.util.MERGE_TYPESAFE)
-    )
+    assert(dst['ms'][2] == 'c')
+    assert("casserole" in dst["mm"])
+    
+    dpath.util.merge(dst, src, flags=dpath.util.MERGE_TYPESAFE)
 
 def test_merge_replace():
     dct_a = {"a": {"b": [1,2,3]}}


### PR DESCRIPTION
This fixes the behavior of LOOSEDICT (and removes the flag), also fixes the fallthrough behavior in TYPESAFE merge related to it.