### PR TITLE
Fixing dpath to work for any type of leaf nodes

### DIFF
--- a/dpath/segments.py
+++ b/dpath/segments.py
@@ -13,7 +13,15 @@ def kvs(node):
     try:
         return iter(node.items())
     except AttributeError:
-        return zip(range(len(node)), node)
+        try:
+            return zip(range(len(node)), node)
+        except TypeError:
+            # we have a mappable object that doesn't implement
+            # items and doesn't have a len either 
+            # Hence we can't actually walk across it
+            # We should still be able to index it
+            return enumerate([])
+
 
 
 def leaf(thing):
@@ -24,7 +32,31 @@ def leaf(thing):
     '''
     leaves = (bytes, str, int, float, bool, type(None))
 
-    return isinstance(thing, leaves)
+    if isinstance(thing, leaves):
+        return True
+
+    try:
+        # we use 0 since this will work on lists and dicts
+        # while using a string will cause the list to 
+        # throw a TypeError too
+        thing[0]
+    except TypeError:
+        # does not implement __getitem__
+        return True
+
+    except (KeyError, IndexError) as e:
+        # this means this has worked but failed at the execution
+        # since key doesn't quite work
+        return False
+    except Exception:
+        # We are probably catching a custom exception
+        # from a custom class that does actually map
+        # and we might want to explore
+        return False
+    else:
+        # if this worked, then it's not a leaf node
+        return False
+
 
 
 def leafy(thing):

--- a/dpath/util.py
+++ b/dpath/util.py
@@ -4,6 +4,7 @@ from dpath import options
 from dpath.exceptions import InvalidKeyName
 import dpath.segments
 
+
 _DEFAULT_SENTINAL = object()
 MERGE_REPLACE = (1 << 1)
 MERGE_ADDITIVE = (1 << 2)

--- a/tests/test_custom_leaf.py
+++ b/tests/test_custom_leaf.py
@@ -1,0 +1,66 @@
+import dpath.util
+from decimal import Decimal
+
+
+
+def test_Decimal():
+    testdict = {
+        "A" : [
+            Decimal(1.5),
+            Decimal(2.25)
+        ]
+    }
+    assert dpath.util.get(testdict, "A")[0] == Decimal(1.5)
+    assert dpath.util.get(testdict, "A/0") == Decimal(1.5) 
+    assert dpath.util.get(testdict, "A/1") == Decimal(2.25)
+
+
+def test_custom_els():
+    func = lambda x: x
+
+    testdict = {
+        "A": func,
+        "B" : [
+            {'a', 'b'}
+        ],
+    }
+
+    assert dpath.util.get(testdict, "A") == func
+    assert dpath.util.get(testdict, "B/0") == {'a', 'b'}
+
+
+class MappableButNotIterable:
+    def __getitem__(self, item):
+        if item in (0, 3,  "hi"):
+            return 4
+        else:
+            raise KeyError("item {} not found".format(item))
+
+
+def test_obtuse_els():
+    testdict = {
+        "C": {
+            "el1" : range(10),
+            "el2" : MappableButNotIterable()
+        }
+    }
+    assert list(dpath.util.get(testdict, "C/el1")) == list(range(10))
+    assert dpath.util.get(testdict, "C/el2") is not None
+
+
+
+def test_odd_mappable():
+    testdict = {
+        "C": {
+            "el2" : MappableButNotIterable()
+        }
+    }
+    try:
+        # this should work since this obj is actually mappable
+        # it doesn't since we walk across it's keys which causes an error
+        assert dpath.util.get(testdict, "C/el2/3") == testdict["C"]["el2"][3]
+    except:
+        import nose
+        raise nose.SkipTest
+    else:
+        assert False, "Test no longer expected fail, please edit"


### PR DESCRIPTION
```python
from decimal import Decimal
ts = {
    "foo" :{
        "dude": Decimal(1.5)
    }
}
>>> dpath.util.get(ts, "foo/dude")
TypeError: object of type 'decimal.Decimal' has no len()
```

Given that `leaf` checks for a finite number of types any kind of odd type such as a function or custom object will simply not work in this dictionary. I've suggested an approach based on duck-typing, in which I check if the object has a `__getitem__` instead of checking particular type (though I do that too for the case of string)

I have a couple of places I wasn't sure about and would love some opinions.

1. When you have an object with a `__getitem__` but no `items` or `len` the kvs method breaks. I've kind of just returned an empty iterator here, but it should be accessible via keys and doesn't really need to have a walk run on it if there is no glob for that field. I currently just treat it as a leaf, but maybe this might be addressed with some kind of warning?
2. I also was worried about catching a generic Exception in `thing[0]` since it could easily be either an indication the object is mappable, but just uses a custom Exception and might have a len/items implemented. I've let it stand right now, but am open to change.