### PR TITLE
#86 : Allow the production of inverse views

### DIFF
--- a/dpath/util.py
+++ b/dpath/util.py
@@ -83,34 +83,7 @@ def delete(obj, glob, separator='/', afilter=None):
         selected = afilter and dpath.segments.leaf(value) and afilter(value)
 
         if (matched and not afilter) or selected:
-            key = segments[-1]
-            parent = dpath.segments.get(obj, segments[:-1])
-
-            try:
-                # Attempt to treat parent like a sequence.
-                parent[0]
-
-                if len(parent) - 1 == key:
-                    # Removing the last element of a sequence. It can be
-                    # truly removed without affecting the ordering of
-                    # remaining items.
-                    #
-                    # Note: In order to achieve proper behavior we are
-                    # relying on the reverse iteration of
-                    # non-dictionaries from dpath.segments.kvs().
-                    # Otherwise we'd be unable to delete all the tails
-                    # of a list and end up with None values when we
-                    # don't need them.
-                    del parent[key]
-                else:
-                    # This key can't be removed completely because it
-                    # would affect the order of items that remain in our
-                    # result.
-                    parent[key] = None
-            except:
-                # Attempt to treat parent like a dictionary instead.
-                del parent[key]
-
+            dpath.segments.delete(obj, segments)
             counter[0] += 1
 
     [deleted] = dpath.segments.foldm(obj, f, [0])

--- a/tests/test_segments.py
+++ b/tests/test_segments.py
@@ -257,7 +257,6 @@ def test_match_nonmatching(pair):
     '''
     Given segments and a known bad glob, match should be False.
     '''
-    print(pair)
     (segments, glob) = pair
     assert api.match(segments, glob) is False
 
@@ -339,3 +338,15 @@ def test_view(walkable):
 
     view = api.view(node, segments)
     assert api.get(view, segments) == api.get(node, segments)
+
+def test_inverse_view():
+    x = api.inverse_view(
+        {'a': {'b': 1, 'c': 2, 'd': {'b': 4}}},
+        ['**', 'b']
+    )
+
+    assert(not api.has(x, ['a', 'b']))
+    assert(not api.has(x, ['a', 'd', 'b']))
+    assert(api.has(x, ['a', 'c']))
+    assert(api.has(x, ['a', 'd']))
+    assert(len(x['a']['d'].keys()) == 0)


### PR DESCRIPTION
This adds dpath.segments.inverse_view which allows us to produce the inverse of a glob - that is, everything that does NOT match it.

```
>>> dpath.segments.inverse_view(
...        {'a': {'b': 1, 'c': 2, 'd': {'b': 4}}},
...        ['**', 'b']
...    )
...
{'a': {'c': 2, 'd': {}}}
```

This functionality is implemented as a modification of the view method because that was the easiest way to get this done. It is NOT the most performant or the most versatile. For example, you can not search, set, or delete according to the inverse of a glob; however you can use a view to produce a new object with the unwanted keys removed, and then perform further operations against the new object. Since it is a view, you will lose any references to the source object, as views produce copies - which is significantly more expensive. However I didn't see a good way to get this done in the existing codebase without significant replumbing.

We should look at a better way to do this in 3.0. Recommend adding a '!' to the pathspec so we can negate all or some of a path, and embed it in the path processor.