### PR TITLE
Enhance filtering and updating for set method

### DIFF
--- a/dpath/util.py
+++ b/dpath/util.py
@@ -120,7 +120,7 @@ def delete(obj, glob, separator='/', afilter=None):
     return deleted
 
 
-def set(obj, glob, value, separator='/', afilter=None):
+def set(obj, glob, value, separator='/', afilter=None, only_leaves=True, update_dict=False):
     '''
     Given a path glob, set all existing elements in the document
     to the given value. Returns the number of elements changed.
@@ -135,9 +135,15 @@ def set(obj, glob, value, separator='/', afilter=None):
             return
 
         matched = dpath.segments.match(segments, globlist)
-        selected = afilter and dpath.segments.leaf(found) and afilter(found)
+        if only_leaves:
+            selected = afilter and dpath.segments.leaf(found) and afilter(found)
+        else:
+            selected = afilter and afilter(found)
 
         if (matched and not afilter) or (matched and selected):
+            nonlocal value
+            if update_dict and isinstance(value, dict):
+                value = {**found, **value}
             dpath.segments.set(obj, segments, value, creator=None)
             counter[0] += 1
 

--- a/tests/test_util_set.py
+++ b/tests/test_util_set.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 import dpath.util
 
 
@@ -28,6 +30,21 @@ def test_set_existing_dict():
 
     dict['a']['b'] = 0
     dpath.util.set(dict, ['a', 'b'], 1)
+    assert(dict['a']['b'] == 1)
+
+
+def test_set_existing_dict_not_affected_by_update_dict_flag():
+    dict = {
+        "a": {
+            "b": 0,
+        },
+    }
+
+    dpath.util.set(dict, '/a/b', 1, update_dict=True)
+    assert(dict['a']['b'] == 1)
+
+    dict['a']['b'] = 0
+    dpath.util.set(dict, ['a', 'b'], 1, update_dict=True)
     assert(dict['a']['b'] == 1)
 
 
@@ -77,6 +94,94 @@ def test_set_filter():
     assert (dict['a']['b'] == 0)
     assert (dict['a']['c'] == 1)
     assert (dict['a']['d'] == 31337)
+
+
+def test_set_filter_not_only_leaves():
+    def afilter(key, value, x):
+        return isinstance(x, dict) and x.get(key) == value
+
+    dict_obj = {
+        "a": {
+            "b": {
+                "name": "value",
+                "b_nested": {
+                    "name": "value",
+                },
+            },
+            "c": 1,
+            "d": 31,
+        }
+    }
+    new_value = "new_value"
+
+    dpath.util.set(dict_obj, '/a/b/*', new_value, afilter=partial(afilter, "name", "value"), only_leaves=False)
+
+    assert dict_obj["a"]["b"]["b_nested"] == new_value
+
+    dict_obj = {
+        "a": {
+            "b": {
+                "name": "value",
+                "b_nested": {
+                    "name": "value",
+                },
+            },
+            "c": 1,
+            "d": 31,
+        }
+    }
+    new_value = "new_value"
+
+    dpath.util.set(dict_obj, ["a", "*"], new_value, afilter=partial(afilter, "name", "value"), only_leaves=False)
+
+    assert dict_obj["a"]["b"] == new_value
+
+
+def test_set_filter_not_only_leaves_and_update_dict_flag():
+    def afilter(key, value, x):
+        return isinstance(x, dict) and x.get(key) == value
+
+    nested_value = "nested_value"
+    new_dict_for_update = {
+        "name": "updated_value"
+    }
+    dict_obj = {
+        "a": {
+            "b": {
+                "name": "value",
+                "b_nested": {
+                    "name": nested_value,
+                },
+            },
+            "c": 1,
+            "d": 31,
+        }
+    }
+
+    dpath.util.set(dict_obj, '/a/*', new_dict_for_update, afilter=partial(afilter, "name", "value"), only_leaves=False,
+                   update_dict=True)
+
+    assert dict_obj["a"]["b"]["b_nested"]["name"] == nested_value
+    assert dict_obj["a"]["b"]["name"] == new_dict_for_update["name"]
+
+    dict_obj = {
+        "a": {
+            "b": {
+                "name": "value",
+                "b_nested": {
+                    "name": nested_value,
+                },
+            },
+            "c": 1,
+            "d": 31,
+        }
+    }
+
+    dpath.util.set(dict_obj, ["a", "*"], new_dict_for_update, afilter=partial(afilter, "name", "value"),
+                   only_leaves=False, update_dict=True)
+
+    assert dict_obj["a"]["b"]["b_nested"]["name"] == nested_value
+    assert dict_obj["a"]["b"]["name"] == new_dict_for_update["name"]
 
 
 def test_set_existing_path_with_separator():


### PR DESCRIPTION
1. Added possibility to filter not only leaves but all dict structures like in search.
Flag parameter "only_leaves" - by default is True and functionality is off (Backward compatibility)

2. Added possibility to update dictionaries (works only with "only_leaves" set to False
and dictionaries nodes). With this flag we can update specified node (dictionary).
By default is set to False (Backward compatibility)